### PR TITLE
fix: update GitHub token reference in workflows

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -19,4 +19,4 @@ jobs:
       - uses: phish108/autotag-action@v1.1.64
         with:
           with-v: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PAT }}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Set the following repository variable and secrets
 - ITCHIO_GAMENAME
 
 ### secrets:
+- PAT
 - BUTLER_API_KEY
 - ITCHIO_USERNAME
 - (Optional) DICORD_WEBHOOK


### PR DESCRIPTION
Changed the GitHub token from GITHUB_TOKEN to PAT in versioning.yaml Added PAT to the README secrets section for clarity.